### PR TITLE
serial compilation fix

### DIFF
--- a/cl-neovim.asd
+++ b/cl-neovim.asd
@@ -9,6 +9,7 @@
                #:vom)
   :serial T
   :components ((:module "src"
+                :serial T
                 :components ((:file "package")
                              (:file "utils")
                              (:file "vim-utils")


### PR DESCRIPTION
When I made changes, the API macro kept using stale cached functions on further quicklisp loads because quicklisp did not know about the dependencies and did not recompile.

Discussed around here: https://irclog.whitequark.org/lisp/2017-11-20#20592787