### PR TITLE
Use `nvim:out-write` in Lisp interface

### DIFF
--- a/rplugin/lisp/__lisp-interface.lisp
+++ b/rplugin/lisp/__lisp-interface.lisp
@@ -9,7 +9,7 @@
     `(let ((,output (with-output-to-string (*standard-output*)
                      ,@forms)))
        (when (> (length ,output) 0)
-         (nvim:command (format nil "echo '~A'" ,output))))))
+         (nvim:out-write (format nil "~A~&" ,output))))))
 
 (defun eval-string (str)
   (eval (read-from-string str)))


### PR DESCRIPTION
Using `(nvim:command "echo '...'")` crashes if the message contains an apostrophe because it terminates the spliced-in message prematurely, leaving nonsense "Vimscript code" in the ex-command.

For example, the message `That's nice` will be turned into the ex-command `echo 'That's nice'`, which is not valid Vimscript.