### PR TITLE
Implement lispeval function for Vimscript

### DIFF
--- a/rplugin/lisp/__lisp-interface.lisp
+++ b/rplugin/lisp/__lisp-interface.lisp
@@ -14,6 +14,9 @@
 (defun eval-string (str)
   (eval (read-from-string str)))
 
+(nvim:defun/s lispeval (form)
+  (declare (type string form))
+  (eval-string form))
 
 (nvim:defcommand/s lisp (&rest form)
   (echo-output (eval-string (format nil "~{~A~^ ~}" form))))


### PR DESCRIPTION
The `Lispeval` function allows calling Lisp code from Vimscript, similarly to `pyeval` and `luaeval`. The function argument is a string of Lisp code, which is the evaluated and the result is returned. This can be useful for example when writing health checks, which have to be written in Vimscript.